### PR TITLE
Add e_sat_goffgratch_water and atmosphere.usStandard

### DIFF
--- a/AI.md
+++ b/AI.md
@@ -44,11 +44,13 @@ CI (`.github/workflows/tests.yml`) runs the test matrix on Python 3.10–3.14 ac
 
 - `meteo_si/__init__.py` imports each topic module as a **namespace**, not a flat function list:
   ```python
-  from . import temperature, humidity, density, wind, constants
+  from . import temperature, humidity, density, wind, constants, atmosphere
   ```
   So calling code uses `meteo_si.humidity.rh2q(...)`, `meteo_si.density.moist_rho_q(...)`, etc. — not `meteo_si.rh2q(...)`. Keep new functions inside the appropriate topic module and export them via that module's `__all__`.
 
-- **Module responsibilities and dependency direction**: `constants.py` (no internal deps) → `temperature.py` / `humidity.py` (both depend on `constants`, and `temperature` also depends on `humidity` for `T_virt_rh`) → `density.py` (depends on `constants` and `humidity`). `wind.py` is independent (circular-mean helpers only). Respect this layering when adding functions — e.g. don't import `density` from `humidity`.
+- **Module responsibilities and dependency direction**: `constants.py` (no internal deps) → `temperature.py` / `humidity.py` (both depend on `constants`, and `temperature` also depends on `humidity` for `T_virt_rh`) → `density.py` (depends on `constants` and `humidity`). `wind.py` and `atmosphere.py` are both independent (circular-mean helpers, and the 1976 US Standard Atmosphere model, respectively — neither needs anything from the other modules). Respect this layering when adding functions — e.g. don't import `density` from `humidity`.
+
+- `humidity.py` has two saturation-vapor-pressure-over-water formulas that are **not interchangeable**: `e_sat_gg_water` (WMO CIMO Guide 2008, Magnus-type) and `e_sat_goffgratch_water` (Goff & Gratch 1946, more accurate over a wider temperature range but pricier to evaluate). Despite the name, `e_sat_gg_water` is the CIMO one, not Goff-Gratch — that's legacy naming, kept for backward compatibility. Every humidity function that depends on saturation pressure (`rh2q`, `rh2a`, `a2rh`, `q2rh`, `rh_to_iwv`) takes an `e_sat_func` parameter (defaulting to `e_sat_gg_water`) for exactly this reason — pick explicitly rather than assuming the default is "the accurate one" or "the Goff-Gratch one".
 
 - Physical quantities are passed as bare floats/arrays with units documented per-function in the docstring (numpy-style `Parameters`/`Returns` sections), not via unit-aware types. When adding a function, follow the existing docstring convention exactly (units in brackets, e.g. `[Pa]`, `[kg/kg]`, `[kg/m3]`) since that's the only unit documentation that exists.
 

--- a/meteo_si/__init__.py
+++ b/meteo_si/__init__.py
@@ -6,6 +6,7 @@ from . import humidity
 from . import density
 from . import wind
 from . import constants
+from . import atmosphere
 
 __all__ = [
     "__version__",
@@ -14,4 +15,5 @@ __all__ = [
     "density",
     "wind",
     "constants",
+    "atmosphere",
 ]

--- a/meteo_si/atmosphere.py
+++ b/meteo_si/atmosphere.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# (c) Ralph Carmichael, Public Domain Aeronautical Software (original
+#     algorithm, http://www.pdas.com/programs/atmos.f90)
+# (c) Maximilian Maahn 2011 (Python translation)
+
+from collections.abc import Iterable
+
+import numpy as np
+
+'''
+Functions to compute properties of the 1976 US Standard Atmosphere.
+
+'''
+
+__all__ = ["usStandard"]
+
+
+def _Atmosphere(alt):
+    """
+    Compute the properties of the 1976 standard atmosphere to 86 km.
+
+    If ``alt`` > 86, the values returned will not be correct, but they
+    will not be too far removed from the correct values for density. The
+    reference document does not use the terms pressure and temperature
+    above 86 km.
+
+    Parameters
+    ----------
+    alt:
+        geometric altitude [km]
+
+    Returns
+    -------
+
+    sigma : float
+        density ratio (density / sea-level standard density)
+    delta : float
+        pressure ratio (pressure / sea-level standard pressure)
+    theta : float
+        temperature ratio (temperature / sea-level standard temperature)
+
+    """
+
+    REARTH = 6369.0  # radius of the Earth (km)
+    GMR = 34.163195  # hydrostatic constant
+    NTAB = 8  # number of entries in the defining tables
+
+    htab = np.array([0.0, 11.0, 20.0, 32.0, 47.0, 51.0, 71.0, 84.852])
+    ttab = np.array(
+        [288.15, 216.65, 216.65, 228.65, 270.65, 270.65, 214.65, 186.946])
+    ptab = np.array(
+        [
+            1.0,
+            2.233611e-1,
+            5.403295e-2,
+            8.5666784e-3,
+            1.0945601e-3,
+            6.6063531e-4,
+            3.9046834e-5,
+            3.68501e-6,
+        ]
+    )
+    gtab = np.array([-6.5, 0.0, 1.0, 2.8, 0.0, -2.8, -2.0, 0.0])
+
+    # convert geometric to geopotential altitude
+    h = alt * REARTH / (alt + REARTH)
+
+    i = 1
+    j = NTAB  # setting up for binary search
+    while True:
+        k = (i + j) // 2  # integer division
+        if h < htab[k - 1]:
+            j = k
+        else:
+            i = k
+        if j <= i + 1:
+            break
+
+    tgrad = gtab[i - 1]  # i will be in 1...NTAB-1
+    tbase = ttab[i - 1]
+    deltah = h - htab[i - 1]
+    tlocal = tbase + tgrad * deltah
+    theta = tlocal / ttab[0]  # temperature ratio
+
+    if tgrad == 0.0:  # pressure ratio
+        delta = ptab[i-1] * np.exp(-GMR * deltah / tbase)
+    else:
+        delta = ptab[i-1] * (tbase / tlocal) ** (GMR / tgrad)
+
+    sigma = delta / theta  # density ratio
+
+    return sigma, delta, theta
+
+
+def usStandard(height):
+    """
+    Compute the US standard atmosphere (1976).
+
+    Source: http://www.pdas.com/programs/atmos.f90
+
+    Parameters
+    ----------
+    height:
+        height [m], as a single value or an array
+
+    Returns
+    -------
+
+    density : float
+        air density [kg / m3]
+    pressure : float
+        air pressure [Pa]
+    temperature : float
+        air temperature [K]
+
+    """
+
+    # check whether height is float or array:
+    if isinstance(height, Iterable):
+        density = np.ones_like(height, dtype=float)
+        pressure = np.ones_like(height, dtype=float)
+        temperature = np.ones_like(height, dtype=float)
+        for ii, hh in enumerate(height):
+            # the reference algorithm processes only a single value at a
+            # time, so make sure it is not itself a vector
+            assert not isinstance(hh, Iterable)
+            density[ii], pressure[ii], temperature[ii] = (
+                _Atmosphere(hh / 1000.0)
+            )
+    else:
+        density, pressure, temperature = _Atmosphere(height / 1000.0)
+
+    # results are normed to standard conditions:
+    density = density * 1.2250
+    pressure = pressure * 101325
+    temperature = temperature * 288.15
+
+    return density, pressure, temperature

--- a/meteo_si/humidity.py
+++ b/meteo_si/humidity.py
@@ -13,7 +13,8 @@ import meteo_si.temperature
 
 
 __all__ = ['a2e', 'e2a', "e2q", "q2e", "rh2q", "rh2a", "rh_to_iwv",
-           "e_sat_gg_ice", "e_sat_gg_water", "q2rh", "a2rh"]
+           "e_sat_gg_ice", "e_sat_gg_water", "e_sat_goffgratch_water",
+           "q2rh", "a2rh"]
 
 
 def a2e(a, T):
@@ -109,6 +110,37 @@ def e_sat_gg_ice(T):
     T = meteo_si.temperature.kelvin_2_celsius(T)
     e_sat_gg_ice = 100 * 6.112 * np.exp(22.46 * T / (272.62 + T))
     return e_sat_gg_ice
+
+
+def e_sat_goffgratch_water(T):
+    """
+    Calculates the saturation pressure over water after Goff and Gratch
+    (1946). More accurate than :func:`e_sat_gg_water` over a wide
+    temperature range (-90 degC to +80 degC), at the cost of a more
+    expensive formula -- the two are not interchangeable results, just two
+    different approximations of the same physical quantity.
+
+    Source: Smithsonian Tables 1984, after Goff and Gratch 1946.
+
+    Parameters
+    ----------
+    T:
+        Temperature in K
+
+    Returns
+    -------
+
+    float :
+        saturation pressure [Pa]
+
+    """
+    e_sat_goffgratch_water = 100 * 1013.246 * 10**(
+        -7.90298*(373.16/T-1)
+        + 5.02808*np.log10(373.16/T)
+        - 1.3816e-7*(10**(11.344*(1-T/373.16))-1)
+        + 8.1328e-3*(10**(-3.49149*(373.16/T-1))-1)
+    )
+    return e_sat_goffgratch_water
 
 
 def e2q(e, p):
@@ -286,7 +318,8 @@ def q2rh(q, T, p, e_sat_func=e_sat_gg_water):
     return rh
 
 
-def rh_to_iwv(relhum_lev, temp_lev, press_lev, hgt_lev):
+def rh_to_iwv(relhum_lev, temp_lev, press_lev, hgt_lev,
+              e_sat_func=e_sat_gg_water):
     """
     Integrate relative humidity to obtain the integrated water vapor (IWV)
     column.
@@ -301,6 +334,9 @@ def rh_to_iwv(relhum_lev, temp_lev, press_lev, hgt_lev):
         pressure at levels [Pa]
     hgt_levels:
         altitude of levels [m]
+    e_sat_func: func, optional
+        Function to estimate the saturation pressure. E.g. e_sat_gg_water for
+        water and e_sat_gg_ice for ice.
 
     Returns
     -------
@@ -317,7 +353,7 @@ def rh_to_iwv(relhum_lev, temp_lev, press_lev, hgt_lev):
     xp = -1.*np.log(press_lev[..., 1:] / press_lev[..., 0:-1]) / dz
     press = -1.*press_lev[..., 0:-1] / xp*(np.exp(-xp*dz)-1.) / dz
 
-    q = rh2q(relhum, temp, press)
+    q = rh2q(relhum, temp, press, e_sat_func=e_sat_func)
     rho_moist = meteo_si.density.moist_rho_q(press, temp, q)
 
     return np.sum(q*rho_moist*dz)

--- a/meteo_si/tests/test_atmosphere.py
+++ b/meteo_si/tests/test_atmosphere.py
@@ -1,0 +1,32 @@
+import numpy as np
+import numpy.testing as npt
+
+import meteo_si
+
+
+def test_usStandard_sea_level():
+    density, pressure, temperature = meteo_si.atmosphere.usStandard(0.0)
+    npt.assert_allclose(density, 1.225, rtol=1e-6)
+    npt.assert_allclose(pressure, 101325.0, rtol=1e-6)
+    npt.assert_allclose(temperature, 288.15, rtol=1e-6)
+
+
+def test_usStandard_decreases_with_height():
+    heights = np.array([0.0, 5000.0, 11000.0, 20000.0])
+    density, pressure, temperature = meteo_si.atmosphere.usStandard(heights)
+    assert np.all(np.diff(density) < 0)
+    assert np.all(np.diff(pressure) < 0)
+    # Temperature drops through the troposphere, then holds ~constant
+    # across the tropopause (11-20 km) in the 1976 standard atmosphere.
+    assert temperature[1] < temperature[0]
+    npt.assert_allclose(temperature[2], temperature[3], rtol=1e-3)
+
+
+def test_usStandard_scalar_matches_array_input():
+    heights = np.array([0.0, 11000.0, 20000.0])
+    scalar_results = [meteo_si.atmosphere.usStandard(h) for h in heights]
+    array_results = meteo_si.atmosphere.usStandard(heights)
+    for i, (density, pressure, temperature) in enumerate(scalar_results):
+        npt.assert_allclose(array_results[0][i], density)
+        npt.assert_allclose(array_results[1][i], pressure)
+        npt.assert_allclose(array_results[2][i], temperature)

--- a/meteo_si/tests/test_humidity.py
+++ b/meteo_si/tests/test_humidity.py
@@ -37,6 +37,32 @@ def test_e_sat_increases_with_temperature():
     assert np.all(np.diff(e_sat) > 0)
 
 
+def test_e_sat_goffgratch_water_reference_point():
+    # Goff-Gratch's own 0 degC value, not the ~611.2 Pa reference point
+    # used to anchor the (different) CIMO Guide formula in e_sat_gg_water
+    # -- see the module-level note on why these two aren't interchangeable.
+    npt.assert_allclose(
+        meteo_si.humidity.e_sat_goffgratch_water(273.15), 610.336,
+        rtol=1e-5)
+
+
+def test_e_sat_goffgratch_water_increases_with_temperature():
+    T = np.array([250.0, 270.0, 290.0, 310.0])
+    e_sat = meteo_si.humidity.e_sat_goffgratch_water(T)
+    assert np.all(np.diff(e_sat) > 0)
+
+
+def test_e_sat_goffgratch_water_diverges_from_e_sat_gg_water():
+    # The two formulas agree closely near 0 degC but are not the same
+    # formula -- confirm they diverge at a more extreme temperature, so an
+    # accidental future de-duplication of the two (e.g. aliasing one to
+    # the other because they "give basically the same answer") gets caught.
+    T = 233.15  # -40 degC
+    gg = meteo_si.humidity.e_sat_gg_water(T)
+    goffgratch = meteo_si.humidity.e_sat_goffgratch_water(T)
+    assert not np.isclose(gg, goffgratch, rtol=1e-3)
+
+
 def test_rh2q_q2rh_roundtrip():
     rh = 0.5
     T = 280.0
@@ -73,6 +99,34 @@ def test_rh2q_with_e_sat_gg_ice():
     q_water = meteo_si.humidity.rh2q(
         rh, T, p, e_sat_func=meteo_si.humidity.e_sat_gg_water)
     assert q < q_water
+
+
+def test_rh2q_with_e_sat_goffgratch_water():
+    rh = 0.5
+    T = 260.0
+    p = 90000.0
+    q_default = meteo_si.humidity.rh2q(rh, T, p)
+    q_goffgratch = meteo_si.humidity.rh2q(
+        rh, T, p, e_sat_func=meteo_si.humidity.e_sat_goffgratch_water)
+    # Close (same physical quantity, similar formulas) but not identical.
+    npt.assert_allclose(q_default, q_goffgratch, rtol=1e-2)
+    assert q_default != q_goffgratch
+
+
+def test_rh_to_iwv_respects_e_sat_func():
+    n = 10
+    relhum_lev = np.full(n, 0.5)
+    temp_lev = np.full(n, 280.0)
+    press_lev = np.linspace(95000.0, 80000.0, n)
+    hgt_lev = np.linspace(0.0, 2000.0, n)
+
+    iwv_default = meteo_si.humidity.rh_to_iwv(
+        relhum_lev, temp_lev, press_lev, hgt_lev)
+    iwv_goffgratch = meteo_si.humidity.rh_to_iwv(
+        relhum_lev, temp_lev, press_lev, hgt_lev,
+        e_sat_func=meteo_si.humidity.e_sat_goffgratch_water)
+    npt.assert_allclose(iwv_default, iwv_goffgratch, rtol=1e-2)
+    assert iwv_default != iwv_goffgratch
 
 
 def test_rh_to_iwv_constant_profile():

--- a/meteo_si/version.py
+++ b/meteo_si/version.py
@@ -1,7 +1,7 @@
 # Format expected by pyproject.toml: string of form "X.Y.Z"
 _version_major = 0
-_version_minor = 1
-_version_micro = 1  # use '' for first of series, number for 1 and above
+_version_minor = 2
+_version_micro = ''  # use '' for first of series, number for 1 and above
 _version_extra = ''  # use e.g. 'dev' for a pre-release
 
 # Construct full version string from these.


### PR DESCRIPTION
Add e_sat_goffgratch_water and atmosphere.usStandard

e_sat_goffgratch_water (humidity.py): the Goff & Gratch (1946) saturation
vapor pressure formula, ported from PAMTRA (igmk/pamtra), which uses it in
both its Python profile-building layer and its Fortran radiative-transfer
core. Added under a new name rather than reusing e_sat_gg_water: despite
the name, that existing function is the WMO CIMO Guide (2008) formula, a
different approximation of the same quantity -- confirmed the two diverge
outside the near-0degC range they happen to agree closely in (new test).
Also threaded an optional e_sat_func through rh_to_iwv (previously always
used the CIMO default internally with no way to override it), matching
the pattern rh2q/rh2a/a2rh/q2rh already use.

atmosphere.py (new module): the 1976 US Standard Atmosphere
(usStandard/_Atmosphere), also ported from PAMTRA -- the underlying
algorithm is Ralph Carmichael's public-domain Fortran (PDAS,
pdas.com/programs/atmos.f90); this is Maahn's own Python translation of
it, previously living only in PAMTRA's meteoSI.py.

Both additions are being consumed by PAMTRA next, replacing its own
duplicate copies where the formulas already match (see igmk/pamtra's
python/pyPamtra/meteoSI.py) -- this bump exists to make that possible via
a normal PyPI dependency rather than a vendored copy.

Bumps to 0.2.0 (new public functions/module, not just a fix).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>